### PR TITLE
feat: add alby client for lightning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ MINT_LIGHTNING_BACKEND=Lnbits
 LNBITS_URL=https://legend.lnbits.com
 LNBITS_ADMIN_KEY=YOUR_ADMIN_KEY
 
+ALBY_API_KEY=YOUR_API_KEY
+
 # absolute path to the lnd macaroon file
 LND_MACAROON_PATH="/.../admin.macaroon"
 # absolute path to the tls certificate

--- a/moksha-mint/src/bin/moksha-mint.rs
+++ b/moksha-mint/src/bin/moksha-mint.rs
@@ -1,6 +1,8 @@
 use mokshamint::{
     info::MintInfoSettings,
-    lightning::{LightningType, LnbitsLightningSettings, LndLightningSettings},
+    lightning::{
+        AlbyLightningSettings, LightningType, LnbitsLightningSettings, LndLightningSettings,
+    },
     MintBuilder,
 };
 use std::{env, fmt, net::SocketAddr, path::PathBuf};
@@ -43,6 +45,12 @@ pub async fn main() -> anyhow::Result<()> {
                 .from_env::<LndLightningSettings>()
                 .expect("Please provide lnd info");
             LightningType::Lnd(lnd_settings)
+        }
+        "Alby" => {
+            let alby_settings = envy::prefixed("ALBY_")
+                .from_env::<AlbyLightningSettings>()
+                .expect("Please provide alby info");
+            LightningType::Alby(alby_settings)
         }
         _ => panic!(
             "env MINT_LIGHTNING_BACKEND not found or invalid values. Valid values are Lnbits and Lnd"

--- a/moksha-mint/src/error.rs
+++ b/moksha-mint/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tonic_lnd::ConnectError;
 use tracing::{event, Level};
 
-use crate::lnbits::LNBitsError;
+use crate::{alby::AlbyError, lnbits::LNBitsError};
 
 #[derive(Error, Debug)]
 pub enum MokshaMintError {
@@ -23,6 +23,9 @@ pub enum MokshaMintError {
 
     #[error("Failed to pay invoice {0} - Error {1}")]
     PayInvoice(String, LNBitsError),
+
+    #[error("Failed to pay invoice {0} - Error {1}")]
+    PayInvoiceAlby(String, AlbyError),
 
     #[error("DB Error {0}")]
     Db(#[from] rocksdb::Error),
@@ -58,7 +61,10 @@ pub enum MokshaMintError {
     InvalidAmount,
 
     #[error("Lightning Error {0}")]
-    Lightning(#[from] LNBitsError),
+    LightningLNBits(#[from] LNBitsError),
+
+    #[error("Lightning Error {0}")]
+    LightningAlby(#[from] AlbyError),
 }
 
 impl IntoResponse for MokshaMintError {

--- a/moksha-mint/src/lib.rs
+++ b/moksha-mint/src/lib.rs
@@ -13,7 +13,7 @@ use error::MokshaMintError;
 use hyper::http::{HeaderName, HeaderValue};
 use hyper::Method;
 use info::{MintInfoResponse, MintInfoSettings, Parameter};
-use lightning::{Lightning, LightningType, LnbitsLightning};
+use lightning::{AlbyLightning, Lightning, LightningType, LnbitsLightning};
 use mint::{LightningFeeConfig, Mint};
 use model::{GetMintQuery, PostMintQuery};
 use moksha_core::model::{
@@ -33,6 +33,7 @@ use tracing::{event, info, Level};
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+mod alby;
 mod database;
 mod error;
 pub mod info;
@@ -88,7 +89,9 @@ impl MintBuilder {
                 lnbits_settings.admin_key.expect("LNBITS_ADMIN_KEY not set"),
                 lnbits_settings.url.expect("LNBITS_URL not set"),
             )),
-
+            Some(LightningType::Alby(alby_settings)) => Arc::new(AlbyLightning::new(
+                alby_settings.api_key.expect("ALBY_API_KEY not set"),
+            )),
             Some(LightningType::Lnd(lnd_settings)) => Arc::new(
                 lightning::LndLightning::new(
                     lnd_settings.grpc_host.expect("LND_GRPC_HOST not set"),

--- a/moksha-mint/src/mint.rs
+++ b/moksha-mint/src/mint.rs
@@ -244,8 +244,8 @@ impl Mint {
 #[cfg(test)]
 mod tests {
     use crate::lightning::{LightningType, MockLightning};
-    use crate::lnbits::PayInvoiceResult;
-    use crate::model::Invoice;
+    use crate::lnbits::LNBitsError;
+    use crate::model::{Invoice, PayInvoiceResult};
     use crate::{database::MockDatabase, error::MokshaMintError, Mint};
     use moksha_core::dhke;
     use moksha_core::model::{BlindedMessage, TokenV3, TotalAmount};
@@ -411,6 +411,7 @@ mod tests {
             Ok(PayInvoiceResult {
                 payment_hash: "hash".to_string(),
             })
+            .map_err(|_err: LNBitsError| MokshaMintError::InvoiceNotFound("".to_string()))
         });
 
         let mint = Mint::new(

--- a/moksha-mint/src/model.rs
+++ b/moksha-mint/src/model.rs
@@ -24,3 +24,24 @@ impl Invoice {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateInvoiceResult {
+    pub payment_hash: Vec<u8>,
+    pub payment_request: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PayInvoiceResult {
+    pub payment_hash: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateInvoiceParams {
+    pub amount: u64,
+    pub unit: String,
+    pub memo: Option<String>,
+    pub expiry: Option<u32>,
+    pub webhook: Option<String>,
+    pub internal: Option<bool>,
+}


### PR DESCRIPTION
Adds Alby API as a lightning backend.

Had to move around some of the Lightning trait components, it wasn't fully abstracted from the LnBits specific impl.

Needs further testing and I want to add an amount enum for sats, msats, and btc. Alby API only operates with sats, need to enforce that if its going to be cross compatible with LND impl.