### PR TITLE
feat: add strike client for lightning backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ MINT_LIGHTNING_BACKEND=Lnbits
 LNBITS_URL=https://legend.lnbits.com
 LNBITS_ADMIN_KEY=YOUR_ADMIN_KEY
 
+ALBY_API_KEY=YOUR_API_KEY
+
 # absolute path to the lnd macaroon file
 LND_MACAROON_PATH="/.../admin.macaroon"
 # absolute path to the tls certificate

--- a/.env.example
+++ b/.env.example
@@ -29,17 +29,24 @@ MINT_INFO_CONTACT=[["email","contact@me.com"]]
 LIGHTNING_FEE_PERCENT=1.0
 LIGHTNING_RESERVE_FEE_MIN=4000
 
-# configure the lightning backend. Valid values are Lnbits and Lnd. If Lnbits is configured all variables starting with LNBITS_ are required. 
-# If Lnd is configured all variables starting with LND_ are required.
+# configure the lightning backend.
+# currently supported backends are:
+# - Lnbits
+# - Alby
+# - Strike
+# - Lnd
+# you are required to set the corresponding environment variables for the backend you want to use
 MINT_LIGHTNING_BACKEND=Lnbits
-#MINT_LIGHTNING_BACKEND=Lnd
-
-
 LNBITS_URL=https://legend.lnbits.com
 LNBITS_ADMIN_KEY=YOUR_ADMIN_KEY
 
+#MINT_LIGHTNING_BACKEND=Alby
 ALBY_API_KEY=YOUR_API_KEY
 
+#MINT_LIGHTNING_BACKEND=Strike
+STRIKE_API_KEY=YOUR_API_KEY
+
+#MINT_LIGHTNING_BACKEND=Lnd
 # absolute path to the lnd macaroon file
 LND_MACAROON_PATH="/.../admin.macaroon"
 # absolute path to the tls certificate

--- a/moksha-mint/src/alby.rs
+++ b/moksha-mint/src/alby.rs
@@ -1,5 +1,4 @@
 use hyper::{header::CONTENT_TYPE, http::HeaderValue};
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::model::{CreateInvoiceParams, CreateInvoiceResult, PayInvoiceResult};

--- a/moksha-mint/src/bin/moksha-mint.rs
+++ b/moksha-mint/src/bin/moksha-mint.rs
@@ -1,6 +1,8 @@
 use mokshamint::{
     info::MintInfoSettings,
-    lightning::{LightningType, LnbitsLightningSettings, LndLightningSettings},
+    lightning::{
+        AlbyLightningSettings, LightningType, LnbitsLightningSettings, LndLightningSettings,
+    },
     MintBuilder,
 };
 use std::{env, fmt, net::SocketAddr, path::PathBuf};
@@ -43,6 +45,12 @@ pub async fn main() -> anyhow::Result<()> {
                 .from_env::<LndLightningSettings>()
                 .expect("Please provide lnd info");
             LightningType::Lnd(lnd_settings)
+        }
+        "Alby" => {
+            let alby_settings = envy::prefixed("ALBY_")
+                .from_env::<AlbyLightningSettings>()
+                .expect("Please provide alby info");
+            LightningType::Alby(alby_settings)
         }
         _ => panic!(
             "env MINT_LIGHTNING_BACKEND not found or invalid values. Valid values are Lnbits and Lnd"

--- a/moksha-mint/src/error.rs
+++ b/moksha-mint/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tonic_lnd::ConnectError;
 use tracing::{event, Level};
 
-use crate::lnbits::LNBitsError;
+use crate::{alby::AlbyError, lnbits::LNBitsError};
 
 #[derive(Error, Debug)]
 pub enum MokshaMintError {
@@ -23,6 +23,9 @@ pub enum MokshaMintError {
 
     #[error("Failed to pay invoice {0} - Error {1}")]
     PayInvoice(String, LNBitsError),
+
+    #[error("Failed to pay invoice {0} - Error {1}")]
+    PayInvoiceAlby(String, AlbyError),
 
     #[error("DB Error {0}")]
     Db(#[from] rocksdb::Error),
@@ -58,7 +61,10 @@ pub enum MokshaMintError {
     InvalidAmount,
 
     #[error("Lightning Error {0}")]
-    Lightning(#[from] LNBitsError),
+    LightningLNBits(#[from] LNBitsError),
+
+    #[error("Lightning Error {0}")]
+    LightningAlby(#[from] AlbyError),
 }
 
 impl IntoResponse for MokshaMintError {

--- a/moksha-mint/src/error.rs
+++ b/moksha-mint/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tonic_lnd::ConnectError;
 use tracing::{event, Level};
 
-use crate::{alby::AlbyError, lnbits::LNBitsError};
+use crate::{alby::AlbyError, lnbits::LNBitsError, strike::StrikeError};
 
 #[derive(Error, Debug)]
 pub enum MokshaMintError {
@@ -26,6 +26,9 @@ pub enum MokshaMintError {
 
     #[error("Failed to pay invoice {0} - Error {1}")]
     PayInvoiceAlby(String, AlbyError),
+
+    #[error("Failed to pay invoice {0} - Error {1}")]
+    PayInvoiceStrike(String, StrikeError),
 
     #[error("DB Error {0}")]
     Db(#[from] rocksdb::Error),
@@ -65,6 +68,9 @@ pub enum MokshaMintError {
 
     #[error("Lightning Error {0}")]
     LightningAlby(#[from] AlbyError),
+
+    #[error("Lightning Error {0}")]
+    LightningStrike(#[from] StrikeError),
 }
 
 impl IntoResponse for MokshaMintError {

--- a/moksha-mint/src/lib.rs
+++ b/moksha-mint/src/lib.rs
@@ -13,7 +13,7 @@ use error::MokshaMintError;
 use hyper::http::{HeaderName, HeaderValue};
 use hyper::Method;
 use info::{MintInfoResponse, MintInfoSettings, Parameter};
-use lightning::{Lightning, LightningType, LnbitsLightning};
+use lightning::{AlbyLightning, Lightning, LightningType, LnbitsLightning};
 use mint::{LightningFeeConfig, Mint};
 use model::{GetMintQuery, PostMintQuery};
 use moksha_core::model::{
@@ -33,6 +33,7 @@ use tracing::{event, info, Level};
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+mod alby;
 mod database;
 mod error;
 pub mod info;
@@ -88,7 +89,9 @@ impl MintBuilder {
                 lnbits_settings.admin_key.expect("LNBITS_ADMIN_KEY not set"),
                 lnbits_settings.url.expect("LNBITS_URL not set"),
             )),
-
+            Some(LightningType::Alby(alby_settings)) => Arc::new(AlbyLightning::new(
+                alby_settings.api_key.expect("ALBY_API_KEY not set"),
+            )),
             Some(LightningType::Lnd(lnd_settings)) => Arc::new(
                 lightning::LndLightning::new(
                     lnd_settings.grpc_host.expect("LND_GRPC_HOST not set"),

--- a/moksha-mint/src/lib.rs
+++ b/moksha-mint/src/lib.rs
@@ -13,7 +13,7 @@ use error::MokshaMintError;
 use hyper::http::{HeaderName, HeaderValue};
 use hyper::Method;
 use info::{MintInfoResponse, MintInfoSettings, Parameter};
-use lightning::{AlbyLightning, Lightning, LightningType, LnbitsLightning};
+use lightning::{AlbyLightning, Lightning, LightningType, LnbitsLightning, StrikeLightning};
 use mint::{LightningFeeConfig, Mint};
 use model::{GetMintQuery, PostMintQuery};
 use moksha_core::model::{
@@ -41,6 +41,7 @@ pub mod lightning;
 mod lnbits;
 pub mod mint;
 mod model;
+mod strike;
 
 #[derive(Debug, Default)]
 pub struct MintBuilder {
@@ -91,6 +92,9 @@ impl MintBuilder {
             )),
             Some(LightningType::Alby(alby_settings)) => Arc::new(AlbyLightning::new(
                 alby_settings.api_key.expect("ALBY_API_KEY not set"),
+            )),
+            Some(LightningType::Strike(strike_settings)) => Arc::new(StrikeLightning::new(
+                strike_settings.api_key.expect("STRIKE_API_KEY not set"),
             )),
             Some(LightningType::Lnd(lnd_settings)) => Arc::new(
                 lightning::LndLightning::new(

--- a/moksha-mint/src/lightning.rs
+++ b/moksha-mint/src/lightning.rs
@@ -245,16 +245,7 @@ impl Lightning for StrikeLightning {
             .0;
 
         // invoiceId is the first 32 bytes of the description hash
-        let invoice_id = hex::encode(&description_hash[..16]);
-        // then convert it to uuid format with hypens
-        let invoice_id = format!(
-            "{}-{}-{}-{}-{}",
-            &invoice_id[..8],
-            &invoice_id[8..12],
-            &invoice_id[12..16],
-            &invoice_id[16..20],
-            &invoice_id[20..]
-        );
+        let invoice_id = format_as_uuid_string(&description_hash[..16]);
         Ok(self.client.is_invoice_paid(&invoice_id).await?)
     }
 
@@ -314,6 +305,18 @@ impl Lightning for StrikeLightning {
             payment_hash: hex::encode(payment_hash),
         })
     }
+}
+
+fn format_as_uuid_string(bytes: &[u8]) -> String {
+    let byte_str = hex::encode(bytes);
+    format!(
+        "{}-{}-{}-{}-{}",
+        &byte_str[..8],
+        &byte_str[8..12],
+        &byte_str[12..16],
+        &byte_str[16..20],
+        &byte_str[20..]
+    )
 }
 
 fn deserialize_url<'de, D>(deserializer: D) -> Result<Option<Url>, D::Error>

--- a/moksha-mint/src/lightning.rs
+++ b/moksha-mint/src/lightning.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-// use serde_derive::{Deserialize, Serialize};
 use std::fmt::{self, Formatter};
 use tokio::sync::{MappedMutexGuard, Mutex, MutexGuard};
 use tonic_lnd::Client;
@@ -41,7 +40,6 @@ impl fmt::Display for LightningType {
 }
 
 #[cfg_attr(test, automock)]
-#[allow(implied_bounds_entailment)]
 #[async_trait]
 pub trait Lightning: Send + Sync {
     async fn is_invoice_paid(&self, invoice: String) -> Result<bool, MokshaMintError>;
@@ -97,7 +95,6 @@ impl LnbitsLightningSettings {
     }
 }
 
-#[allow(implied_bounds_entailment)]
 #[async_trait]
 impl Lightning for LnbitsLightning {
     async fn is_invoice_paid(&self, invoice: String) -> Result<bool, MokshaMintError> {
@@ -165,7 +162,6 @@ impl AlbyLightning {
     }
 }
 
-#[allow(implied_bounds_entailment)]
 #[async_trait]
 impl Lightning for AlbyLightning {
     async fn is_invoice_paid(&self, invoice: String) -> Result<bool, MokshaMintError> {
@@ -233,7 +229,6 @@ impl StrikeLightning {
     }
 }
 
-#[allow(implied_bounds_entailment)]
 #[async_trait]
 impl Lightning for StrikeLightning {
     async fn is_invoice_paid(&self, invoice: String) -> Result<bool, MokshaMintError> {

--- a/moksha-mint/src/lnbits.rs
+++ b/moksha-mint/src/lnbits.rs
@@ -1,5 +1,4 @@
 use hyper::{header::CONTENT_TYPE, http::HeaderValue};
-use serde::{Deserialize, Serialize};
 use url::Url;
 
 use crate::model::{CreateInvoiceParams, CreateInvoiceResult, PayInvoiceResult};

--- a/moksha-mint/src/mint.rs
+++ b/moksha-mint/src/mint.rs
@@ -244,8 +244,8 @@ impl Mint {
 #[cfg(test)]
 mod tests {
     use crate::lightning::{LightningType, MockLightning};
-    use crate::lnbits::PayInvoiceResult;
-    use crate::model::Invoice;
+    use crate::lnbits::LNBitsError;
+    use crate::model::{Invoice, PayInvoiceResult};
     use crate::{database::MockDatabase, error::MokshaMintError, Mint};
     use moksha_core::dhke;
     use moksha_core::model::{BlindedMessage, TokenV3, TotalAmount};
@@ -411,6 +411,7 @@ mod tests {
             Ok(PayInvoiceResult {
                 payment_hash: "hash".to_string(),
             })
+            .map_err(|_err: LNBitsError| MokshaMintError::InvoiceNotFound("".to_string()))
         });
 
         let mint = Mint::new(

--- a/moksha-mint/src/model.rs
+++ b/moksha-mint/src/model.rs
@@ -24,3 +24,24 @@ impl Invoice {
         }
     }
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateInvoiceResult {
+    pub payment_hash: Vec<u8>,
+    pub payment_request: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PayInvoiceResult {
+    pub payment_hash: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateInvoiceParams {
+    pub amount: u64,
+    pub unit: String,
+    pub memo: Option<String>,
+    pub expiry: Option<u32>,
+    pub webhook: Option<String>,
+    pub internal: Option<bool>,
+}

--- a/moksha-mint/src/strike.rs
+++ b/moksha-mint/src/strike.rs
@@ -1,0 +1,214 @@
+use hyper::{header::CONTENT_TYPE, http::HeaderValue};
+use lightning_invoice::{Bolt11Invoice, SignedRawBolt11Invoice};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::model::{CreateInvoiceParams, CreateInvoiceResult, PayInvoiceResult};
+
+#[derive(Debug, thiserror::Error)]
+pub enum StrikeError {
+    #[error("reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error("url error: {0}")]
+    UrlError(#[from] url::ParseError),
+
+    #[error("serde error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+
+    #[error("Not found")]
+    NotFound,
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Payment Failed")]
+    PaymentFailed,
+}
+
+#[derive(Clone)]
+pub struct StrikeClient {
+    api_key: String,
+    strike_url: Url,
+    reqwest_client: reqwest::Client,
+}
+
+impl StrikeClient {
+    pub fn new(api_key: &str) -> Result<StrikeClient, StrikeError> {
+        let strike_url = Url::parse("https://api.strike.me")?;
+
+        let reqwest_client = reqwest::Client::builder().build()?;
+
+        Ok(StrikeClient {
+            api_key: api_key.to_owned(),
+            strike_url,
+            reqwest_client,
+        })
+    }
+}
+
+impl StrikeClient {
+    pub async fn make_get(&self, endpoint: &str) -> Result<String, StrikeError> {
+        let url = self.strike_url.join(endpoint)?;
+        let response = self
+            .reqwest_client
+            .get(url)
+            .bearer_auth(self.api_key.clone())
+            .send()
+            .await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(StrikeError::NotFound);
+        }
+
+        Ok(response.text().await?)
+    }
+
+    pub async fn make_post(&self, endpoint: &str, body: &str) -> Result<String, StrikeError> {
+        let url = self.strike_url.join(endpoint)?;
+        let response = self
+            .reqwest_client
+            .post(url)
+            .bearer_auth(self.api_key.clone())
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_str("application/json").expect("Invalid header value"),
+            )
+            .body(body.to_string())
+            .send()
+            .await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(StrikeError::NotFound);
+        }
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(StrikeError::Unauthorized);
+        }
+
+        Ok(response.text().await?)
+    }
+
+    pub async fn make_patch(&self, endpoint: &str, body: &str) -> Result<String, StrikeError> {
+        let url = self.strike_url.join(endpoint)?;
+        let response = self
+            .reqwest_client
+            .patch(url)
+            .bearer_auth(self.api_key.clone())
+            .header(
+                CONTENT_TYPE,
+                HeaderValue::from_str("application/json").expect("Invalid header value"),
+            )
+            .body(body.to_string())
+            .send()
+            .await?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Err(StrikeError::NotFound);
+        }
+
+        if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+            return Err(StrikeError::Unauthorized);
+        }
+
+        Ok(response.text().await?)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QuoteRequest {
+    pub description_hash: String,
+}
+
+// strike has a 2 step process for getting a lightning invoice
+// 1. create an "invoice" which on their platform means a currency agnostic payment request
+// 2. generate a "quote" for the invoice which is a specific quoted conversion rate and a lightning invoice
+impl StrikeClient {
+    // this is not a lightning invoice, it's the strike internal representation of an invoice
+    pub async fn create_strike_invoice(
+        &self,
+        params: &CreateInvoiceParams,
+    ) -> Result<String, StrikeError> {
+        let btc = params.amount / 100000000;
+        let params = serde_json::json!({
+            "amount": {
+                "amount": btc,
+                "currency": "BTC"
+            },
+            "description": params.memo,
+        });
+        let body = self
+            .make_post("v1/invoices", &serde_json::to_string(&params)?)
+            .await?;
+
+        let response: serde_json::Value = serde_json::from_str(&body)?;
+        let invoice_id = response["invoiceId"]
+            .as_str()
+            .expect("invoiceId is empty")
+            .to_owned();
+
+        Ok(invoice_id)
+    }
+
+    // this is how you get the actual lightning invoice
+    pub async fn create_strike_quote(&self, invoice_id: &str) -> Result<String, StrikeError> {
+        let endpoint = format!("v1/invoices/{}/quote", invoice_id);
+        let description_hash = format!(
+            "{:0>64}",
+            hex::encode(hex::decode(invoice_id.replace("-", "").as_bytes()).unwrap())
+        );
+
+        let params = QuoteRequest { description_hash };
+        let body = self
+            .make_post(&endpoint, &serde_json::to_string(&params)?)
+            .await?;
+        let response: serde_json::Value = serde_json::from_str(&body)?;
+        let payment_request = response["lnInvoice"]
+            .as_str()
+            .expect("lnInvoice is empty")
+            .to_owned();
+
+        Ok(payment_request)
+    }
+
+    pub async fn create_ln_payment_quote(&self, bolt11: &str) -> Result<String, StrikeError> {
+        let endpoint = format!("v1/payment-quotes/lightning");
+        let params = serde_json::json!({
+            "lnInvoice": bolt11,
+            "sourceCurrency": "BTC",
+        });
+        let body = self
+            .make_post(&endpoint, &serde_json::to_string(&params)?)
+            .await?;
+        let response: serde_json::Value = serde_json::from_str(&body)?;
+        let payment_quote_id = response["paymentQuoteId"]
+            .as_str()
+            .expect("paymentQuoteId is empty")
+            .to_owned();
+
+        Ok(payment_quote_id)
+    }
+
+    pub async fn execute_ln_payment_quote(&self, quote_id: &str) -> Result<bool, StrikeError> {
+        let endpoint = format!("v1/payment-quotes/{}/execute", quote_id);
+        let body = self
+            .make_patch(&endpoint, &serde_json::to_string(&serde_json::json!({}))?)
+            .await?;
+        let response: serde_json::Value = serde_json::from_str(&body)?;
+
+        let state = response["state"].as_str().unwrap_or("");
+        let is_paid = matches!(state, "COMPLETED");
+
+        Ok(is_paid)
+    }
+
+    pub async fn is_invoice_paid(&self, invoice_id: &str) -> Result<bool, StrikeError> {
+        let body = self.make_get(&format!("invoices/{invoice_id}")).await?;
+        let response = serde_json::from_str::<serde_json::Value>(&body)?;
+
+        let state = response["state"].as_str().unwrap_or("");
+        let is_paid = matches!(state, "PAID");
+
+        Ok(is_paid)
+    }
+}


### PR DESCRIPTION
(*Builds off of Alby Client abstractions I made so that one needs merge first.*)

Adds Strike API as lightning backend.

 I'm running a fork of moksha where I'll be doing dollar denominated cashu ecash swapping BTC<>USD using the strike api, upstreaming this client impl I'm using for it.

Needs further testing and cool if you don't want to have strike api at all as a client in upstream moksha, can close this if not.