### PR TITLE
DRAFT: feat: lightning module refactor

### DIFF
--- a/moksha-mint/src/bin/moksha-mint.rs
+++ b/moksha-mint/src/bin/moksha-mint.rs
@@ -2,6 +2,7 @@ use mokshamint::{
     info::MintInfoSettings,
     lightning::{
         AlbyLightningSettings, LightningType, LnbitsLightningSettings, LndLightningSettings,
+        StrikeLightningSettings,
     },
     MintBuilder,
 };
@@ -52,8 +53,14 @@ pub async fn main() -> anyhow::Result<()> {
                 .expect("Please provide alby info");
             LightningType::Alby(alby_settings)
         }
+        "Strike" => {
+            let strike_settings = envy::prefixed("STRIKE_")
+                .from_env::<StrikeLightningSettings>()
+                .expect("Please provide strike info");
+            LightningType::Strike(strike_settings)
+        }
         _ => panic!(
-            "env MINT_LIGHTNING_BACKEND not found or invalid values. Valid values are Lnbits and Lnd"
+            "env MINT_LIGHTNING_BACKEND not found or invalid values. Valid values are Lnbits, Lnd, Alby, and Strike"
         ),
     };
 

--- a/moksha-mint/src/error.rs
+++ b/moksha-mint/src/error.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use tonic_lnd::ConnectError;
 use tracing::{event, Level};
 
-use crate::{alby::AlbyError, lnbits::LNBitsError, strike::StrikeError};
+use crate::lightning::error::LightningError;
 
 #[derive(Error, Debug)]
 pub enum MokshaMintError {
@@ -22,13 +22,7 @@ pub enum MokshaMintError {
     DecodeInvoice(String, ParseOrSemanticError),
 
     #[error("Failed to pay invoice {0} - Error {1}")]
-    PayInvoice(String, LNBitsError),
-
-    #[error("Failed to pay invoice {0} - Error {1}")]
-    PayInvoiceAlby(String, AlbyError),
-
-    #[error("Failed to pay invoice {0} - Error {1}")]
-    PayInvoiceStrike(String, StrikeError),
+    PayInvoice(String, LightningError),
 
     #[error("DB Error {0}")]
     Db(#[from] rocksdb::Error),
@@ -64,13 +58,7 @@ pub enum MokshaMintError {
     InvalidAmount,
 
     #[error("Lightning Error {0}")]
-    LightningLNBits(#[from] LNBitsError),
-
-    #[error("Lightning Error {0}")]
-    LightningAlby(#[from] AlbyError),
-
-    #[error("Lightning Error {0}")]
-    LightningStrike(#[from] StrikeError),
+    Lightning(#[from] LightningError),
 }
 
 impl IntoResponse for MokshaMintError {

--- a/moksha-mint/src/lib.rs
+++ b/moksha-mint/src/lib.rs
@@ -33,15 +33,12 @@ use tracing::{event, info, Level};
 use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-mod alby;
 mod database;
 mod error;
 pub mod info;
 pub mod lightning;
-mod lnbits;
 pub mod mint;
 mod model;
-mod strike;
 
 #[derive(Debug, Default)]
 pub struct MintBuilder {

--- a/moksha-mint/src/lightning/error.rs
+++ b/moksha-mint/src/lightning/error.rs
@@ -1,0 +1,20 @@
+#[derive(Debug, thiserror::Error)]
+pub enum LightningError {
+    #[error("reqwest error: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
+    #[error("url error: {0}")]
+    UrlError(#[from] url::ParseError),
+
+    #[error("serde error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+
+    #[error("Not found")]
+    NotFound,
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Payment failed")]
+    PaymentFailed,
+}

--- a/moksha-mint/src/mint.rs
+++ b/moksha-mint/src/mint.rs
@@ -243,8 +243,8 @@ impl Mint {
 
 #[cfg(test)]
 mod tests {
+    use crate::lightning::error::LightningError;
     use crate::lightning::{LightningType, MockLightning};
-    use crate::lnbits::LNBitsError;
     use crate::model::{Invoice, PayInvoiceResult};
     use crate::{database::MockDatabase, error::MokshaMintError, Mint};
     use moksha_core::dhke;
@@ -411,7 +411,7 @@ mod tests {
             Ok(PayInvoiceResult {
                 payment_hash: "hash".to_string(),
             })
-            .map_err(|_err: LNBitsError| MokshaMintError::InvoiceNotFound("".to_string()))
+            .map_err(|_err: LightningError| MokshaMintError::InvoiceNotFound("".to_string()))
         });
 
         let mint = Mint::new(


### PR DESCRIPTION
Moved all the lightning backends into a module folder to separate out from rest of mint and eventually add more backends.

contains some fixes on alby and strike apis from testing today (e.g. alby returns 404 for unpaid invoice, no way to look up invoice status for unsettled invoice using the api which is weird bc they have lnurl verify) didn't realize you were going to merge them so fast haha still had to test some more

can you enable draft pull requests?