### PR TITLE
make blinded messages in melt optional

### DIFF
--- a/moksha-core/src/primitives.rs
+++ b/moksha-core/src/primitives.rs
@@ -201,7 +201,7 @@ impl From<Bolt11MeltQuote> for PostMeltQuoteBolt11Response {
 pub struct PostMeltBolt11Request {
     pub quote: String,
     pub inputs: Proofs,
-    pub outputs: Vec<BlindedMessage>,
+    pub outputs: Option<Vec<BlindedMessage>>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, ToSchema)]

--- a/moksha-mint/src/routes/default.rs
+++ b/moksha-mint/src/routes/default.rs
@@ -257,7 +257,7 @@ pub async fn post_melt_bolt11(
             quote.payment_request.to_owned(),
             quote.fee_reserve,
             &melt_request.inputs,
-            &melt_request.outputs,
+            melt_request.outputs,
             &mint.keyset,
         )
         .await?;

--- a/moksha-wallet/src/client/crossplatform.rs
+++ b/moksha-wallet/src/client/crossplatform.rs
@@ -61,7 +61,7 @@ impl CashuClient for CrossPlatformHttpClient {
         let body = PostMeltBolt11Request {
             quote,
             inputs,
-            outputs,
+            outputs: Some(outputs),
         };
 
         self.do_post(&mint_url.join("v1/melt/bolt11")?, &body).await


### PR DESCRIPTION
Changed the `PostMeltBolt11Request` struct to have optional `outputs` instead of required. Mint would throw an error if it received a melt request without the `outputs` field but it shouldn't since that field is optional from NUT-08