### PR TITLE
fix lnbits create_invoice error response

### DIFF
--- a/moksha-mint/src/lightning/lnbits.rs
+++ b/moksha-mint/src/lightning/lnbits.rs
@@ -170,17 +170,12 @@ impl LNBitsClient {
         &self,
         params: &CreateInvoiceParams,
     ) -> Result<CreateInvoiceResult, LightningError> {
-        // Add out: true to the params
-        let params = serde_json::json!({
-            "out": false,
-            "amount": params.amount,
-            "unit": params.unit,
-            "memo": params.memo,
-            "webhook": params.webhook,
-            "internal": params.internal,
-            "expiry": params.expiry,
-        });
+        let mut params = serde_json::to_value(&params)?;
 
+        // Add out: false to the params
+        if let serde_json::Value::Object(ref mut map) = params {
+            map.insert("out".to_string(), serde_json::Value::Bool(false));
+        }
         let body = self
             .make_post("api/v1/payments", &serde_json::to_string(&params)?)
             .await?;

--- a/moksha-mint/src/model.rs
+++ b/moksha-mint/src/model.rs
@@ -32,8 +32,12 @@ pub struct PayInvoiceResult {
 pub struct CreateInvoiceParams {
     pub amount: u64,
     pub unit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expiry: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub internal: Option<bool>,
 }


### PR DESCRIPTION
In latest version of lnbits, "/api/v1/payments" endpoint does not allow null value in create_invoice optional request parameter, this pull request fixes the issue so lnbits can be used for mint backend.
I verified it works for Alby as well, but I don't have Strike account so I cannot verify if it works on Strike or not. Hopefully someone can test it on Strike as well.