### PR TITLE
add required name var to buildRustPackage expression

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,11 @@
           pkgs.wasm-pack
           pkgs.wasm-bindgen-cli
           pkgs.binaryen
-	  pkgs.clang
-	];
-      in
-      {
+          pkgs.clang
+        ];
+      in {
         defaultPackage = pkgs.rustPlatform.buildRustPackage {
+          name = "moksha";
           src = ./.;
 
           cargoLock = {


### PR DESCRIPTION
`name` is required to build the package. 
formatter did a weird thing with the `clang` input but it's a no-op.